### PR TITLE
fix(manifest.xml): sideload add-in on web - #4

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -24,7 +24,6 @@
             <Description resid="GetStarted.Description"/>
             <LearnMoreUrl resid="GetStarted.LearnMoreUrl"/>
           </GetStarted>
-          <FunctionFile resid="Commands.Url"/>
           <ExtensionPoint xsi:type="PrimaryCommandSurface">
             <OfficeTab id="TabHome">
               <Group id="CommandsGroup">


### PR DESCRIPTION
Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>

Fixes: #4 

Initially there was a `commands` component which was included in the boilerplate. A URL was defined for this component which was removed in this commit -  https://github.com/accordproject/cicero-word-add-in/commit/819a24f58aeed8e531e3ac103250b218cb41ad89#diff-29ef6f5c30334151da1bfd924cd8c761L68.

We also had to remove the tag which referred to this URL which is done in this PR. Here is the [StackOverflow answer](https://stackoverflow.com/a/57854190/11751642) which explained it more clearly.

Please try side loading it on your system as well. These changes makes it work on my system.