### PR TITLE
fix(VariableChangeListener): update values of variables on the web

### DIFF
--- a/src/utils/VariableChangeListener/index.js
+++ b/src/utils/VariableChangeListener/index.js
@@ -2,33 +2,39 @@ const variableChangeListener = event => {
   const { binding } = event;
   // ID of the binding the user changed
   const bindingId = binding.id;
-  binding.getDataAsync(result => {
-    // The text typed by user to change it
-    const data = result.value;
-    Word.run(async context => {
-      // Get all the simlar variables
-      const contentControl = context.document.contentControls.getByTitle(bindingId).getFirst();
-      contentControl.load('tag');
-      await context.sync();
-      const tag = contentControl.tag;
-      const contentControls = context.document.contentControls.getByTag(tag);
-      contentControls.load('items/length');
-      await context.sync();
-      // To prevent it from an infinite loop, we check if text inside all the variables is same or not.
-      let contentControlText = [];
-      for(let index=0; index<contentControls.items.length; ++index) {
-        let textRange = contentControls.items[index].getRange();
-        textRange.load('text');
-        await context.sync();
-        contentControlText = [textRange.text, ...contentControlText];
+  Office.context.document.bindings.getByIdAsync(bindingId, asyncResult => {
+    asyncResult.value.getDataAsync(result => {
+      if (result.status === Office.AsyncResultStatus.Failed) {
+        console.error(result);
       }
-      if (contentControlText.every(el => el === contentControlText[0])) {
-        return;
+      else {
+        const data = result.value;
+        Word.run(async context => {
+          // Get all the simlar variables
+          const contentControl = context.document.contentControls.getByTitle(bindingId).getFirst();
+          contentControl.load('tag');
+          await context.sync();
+          const tag = contentControl.tag;
+          const contentControls = context.document.contentControls.getByTag(tag);
+          contentControls.load('items/length');
+          await context.sync();
+          // To prevent it from an infinite loop, we check if text inside all the variables is same or not.
+          let contentControlText = [];
+          for(let index=0; index<contentControls.items.length; ++index) {
+            let textRange = contentControls.items[index].getRange();
+            textRange.load('text');
+            await context.sync();
+            contentControlText = [textRange.text, ...contentControlText];
+          }
+          if (contentControlText.every(el => el === contentControlText[0])) {
+            return;
+          }
+          for(let index=0; index<contentControls.items.length; ++index) {
+            contentControls.items[index].insertText(data, Word.InsertLocation.replace);
+          }
+          return context.sync();
+        });
       }
-      for(let index=0; index<contentControls.items.length; ++index) {
-        contentControls.items[index].insertText(data, Word.InsertLocation.replace);
-      }
-      return context.sync();
     });
   });
 };


### PR DESCRIPTION
Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>

These changes make editing of variable values possible on the web as well. But the font styles get messed up somehow.
![web-demo_edit_0](https://user-images.githubusercontent.com/35191225/86443566-14e5bd80-bd2d-11ea-9422-e16f7957bf7d.gif)

What I have done here is quite redundant though since I already had [reference to a binding](https://github.com/accordproject/cicero-word-add-in/compare/update-values-on-web?expand=1#diff-4effbc6ba4431d509d2a1997d1d119c6R2) but I am getting it again [here](https://github.com/accordproject/cicero-word-add-in/compare/update-values-on-web?expand=1#diff-4effbc6ba4431d509d2a1997d1d119c6R5) and then getting its value. But [this](https://github.com/OfficeDev/office-js/issues/1233#issuecomment-653313680) is what the people at MS suggested.

Once they fix the [bug here](https://github.com/OfficeDev/office-js/issues/1233#issuecomment-653293125), I think we can revert these changes.