### PR TITLE
feat(CiceroMarkToOOXML): assign heading styles to different levels

### DIFF
--- a/src/utils/CiceroMarkToOOXML/index.js
+++ b/src/utils/CiceroMarkToOOXML/index.js
@@ -2,17 +2,18 @@ import attachVariableChangeListener from '../AttachVariableChangeListener';
 
 const insertHeading = async (context, value, level) => {
   const definedLevels = {
-    1: Word.Style.heading1,
-    2: Word.Style.heading2,
-    3: Word.Style.heading3,
-    4: Word.Style.heading4,
-    5: Word.Style.heading5,
-    6: Word.Style.heading6,
+    1: { style: Word.Style.heading1, size: 25 },
+    2: { style: Word.Style.heading2, size: 20 },
+    3: { style: Word.Style.heading3, size: 16 },
+    4: { style: Word.Style.heading4, size: 16 },
+    5: { style: Word.Style.heading5, size: 16 },
+    6: { style: Word.Style.heading6, size: 16 },
   };
   const heading = context.document.body.insertParagraph(value, Word.InsertLocation.end);
-  heading.styleBuiltIn = definedLevels[level];
+  heading.styleBuiltIn = definedLevels[level].style;
   heading.font.set({
     highlightColor: null,
+    size: definedLevels[level].size,
   });
   insertLineBreak(context);
   await context.sync();
@@ -32,7 +33,7 @@ const insertText = async (context, value) => {
   context.document.body.insertText(value, Word.InsertLocation.end).font.set({
     color: 'black',
     highlightColor: null,
-    size: 14,
+    size: 12,
   });
   await context.sync();
 };
@@ -45,7 +46,7 @@ const insertVariable = async (context, title, tag, value) => {
   contentControl.font.set({
     color: 'black',
     highlightColor: 'lime',
-    size: 14,
+    size: 12,
   });
   await context.sync();
 

--- a/src/utils/CiceroMarkToOOXML/index.js
+++ b/src/utils/CiceroMarkToOOXML/index.js
@@ -2,17 +2,17 @@ import attachVariableChangeListener from '../AttachVariableChangeListener';
 
 const insertHeading = async (context, value, level) => {
   const definedLevels = {
-    1: 28,
-    2: 26,
-    3: 24,
-    4: 22,
-    5: 20,
-    6: 18,
+    1: Word.Style.heading1,
+    2: Word.Style.heading2,
+    3: Word.Style.heading3,
+    4: Word.Style.heading4,
+    5: Word.Style.heading5,
+    6: Word.Style.heading6,
   };
-  context.document.body.insertParagraph(value, Word.InsertLocation.end).font.set({
-    color: 'black',
+  const heading = context.document.body.insertParagraph(value, Word.InsertLocation.end);
+  heading.styleBuiltIn = definedLevels[level];
+  heading.font.set({
     highlightColor: null,
-    size: definedLevels[level],
   });
   insertLineBreak(context);
   await context.sync();


### PR DESCRIPTION
Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>

I have added heading styles to heading instead of assigning font sizes.
![heading](https://user-images.githubusercontent.com/35191225/87717909-c88b8a80-c7ce-11ea-9e2a-638fa5e23668.PNG)

Currently,
- Heading size is `13` with its default colour which comes with style `Heading2` of Word.
- Body size is `14`.

I would like some suggestions on the colour of the heading and its size.