### PR TITLE
feat(TemplateLibrary): add extra line break before rendering the document

### DIFF
--- a/src/components/TemplateLibrary/index.js
+++ b/src/components/TemplateLibrary/index.js
@@ -26,6 +26,7 @@ const LibraryComponent = () => {
   const setup = async dom => {
     await Word.run(async context => {
       let counter = {};
+      context.document.body.insertBreak(Word.BreakType.line, Word.InsertLocation.end);
       dom.nodes.forEach(node => {
         renderNodes(context, node, counter);
       });


### PR DESCRIPTION
These changes are a workaround for https://github.com/OfficeDev/office-js/issues/1284

Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>