### PR TITLE
feat(CiceroMarkToOOXML): render `list`, `listVariable` and `item`

### DIFF
--- a/src/constants/UnorderedListSpec.js
+++ b/src/constants/UnorderedListSpec.js
@@ -1,0 +1,37 @@
+const unorderedListSpec = `
+  <pkg:part pkg:name="/word/_rels/document.xml.rels" pkg:contentType="application/vnd.openxmlformats-package.relationships+xml" pkg:padding="256">
+      <pkg:xmlData>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+        </Relationships>
+      </pkg:xmlData>
+  </pkg:part>
+  <pkg:part pkg:name="/word/numbering.xml" pkg:contentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml">
+  <pkg:xmlData>
+    <w:numbering xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex" xmlns:cx1="http://schemas.microsoft.com/office/drawing/2015/9/8/chartex" xmlns:cx2="http://schemas.microsoft.com/office/drawing/2015/10/21/chartex" xmlns:cx3="http://schemas.microsoft.com/office/drawing/2016/5/9/chartex" xmlns:cx4="http://schemas.microsoft.com/office/drawing/2016/5/10/chartex" xmlns:cx5="http://schemas.microsoft.com/office/drawing/2016/5/11/chartex" xmlns:cx6="http://schemas.microsoft.com/office/drawing/2016/5/12/chartex" xmlns:cx7="http://schemas.microsoft.com/office/drawing/2016/5/13/chartex" xmlns:cx8="http://schemas.microsoft.com/office/drawing/2016/5/14/chartex" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:aink="http://schemas.microsoft.com/office/drawing/2016/ink" xmlns:am3d="http://schemas.microsoft.com/office/drawing/2017/model3d" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:w16cex="http://schemas.microsoft.com/office/word/2018/wordml/cex" xmlns:w16cid="http://schemas.microsoft.com/office/word/2016/wordml/cid" xmlns:w16="http://schemas.microsoft.com/office/word/2018/wordml" xmlns:w16se="http://schemas.microsoft.com/office/word/2015/wordml/symex" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" mc:Ignorable="w14 w15 w16se w16cid w16 w16cex wp14">
+      <w:abstractNum w:abstractNumId="0" w15:restartNumberingAfterBreak="0">
+        <w:nsid w:val="75DE1041"/>
+        <w:multiLevelType w:val="hybridMultilevel"/>
+        <w:tmpl w:val="7BAC167E"/>
+        <w:lvl w:ilvl="1" w:tplc="04090001">
+          <w:start w:val="1"/>
+          <w:numFmt w:val="bullet"/>
+          <w:lvlText w:val="&#xF0B7;"/>
+          <w:lvlJc w:val="left"/>
+          <w:pPr>
+            <w:ind w:left="720" w:hanging="360"/>
+          </w:pPr>
+          <w:rPr>
+            <w:rFonts w:ascii="Symbol" w:hAnsi="Symbol" w:hint="default"/>
+          </w:rPr>
+        </w:lvl>
+      </w:abstractNum>
+      <w:num w:numId="2">
+        <w:abstractNumId w:val="0" />
+      </w:num>
+    </w:numbering>
+  </pkg:xmlData>
+  </pkg:part>
+`;
+
+export default unorderedListSpec;

--- a/src/utils/CiceroMarkToOOXML/index.js
+++ b/src/utils/CiceroMarkToOOXML/index.js
@@ -90,7 +90,7 @@ const definedNodes = {
   heading: 'org.accordproject.commonmark.Heading',
   item: 'org.accordproject.commonmark.Item',
   list: 'org.accordproject.commonmark.List',
-  listVariable: 'org.accordproject.ciceromark.ListVariable',
+  listBlock: 'org.accordproject.ciceromark.ListBlock',
   paragraph: 'org.accordproject.commonmark.Paragraph',
   softbreak: 'org.accordproject.commonmark.Softbreak',
   text: 'org.accordproject.commonmark.Text',
@@ -136,7 +136,7 @@ const renderNodes = (context, node, counter, parent=null) => {
       renderNodes(context, subNode, counter, { class: node.$class });
     });
   }
-  if (node.$class === definedNodes.listVariable || node.$class === definedNodes.list) {
+  if (node.$class === definedNodes.listBlock || node.$class === definedNodes.list) {
     switch (node.type) {
     case 'ordered':
       insertList(context, node, 'ol');

--- a/src/utils/CiceroMarkToOOXML/index.js
+++ b/src/utils/CiceroMarkToOOXML/index.js
@@ -1,4 +1,6 @@
 import attachVariableChangeListener from '../AttachVariableChangeListener';
+import sanitizeHtmlChars from '../SanitizeHtmlChars';
+import unorderedListSpec from '../../constants/UnorderedListSpec';
 
 const insertHeading = async (context, value, level) => {
   const definedLevels = {
@@ -57,22 +59,71 @@ const insertVariable = async (context, title, tag, value) => {
 };
 
 const insertList = async (context, node, type) => {
-  let html = `<br><${type}>`;
+  let ooxml = '';
   node.nodes.forEach(subNode => {
-    html += `<li>${getListItem(subNode)}</li>`;
+    ooxml += `
+      <w:p>
+        <w:pPr>
+          <w:pStyle w:val="ListParagraph"/>
+          <w:numPr>
+            <w:ilvl w:val="1"/>
+            <w:numId w:val="2"/>
+          </w:numPr>
+        </w:pPr>
+        ${getListItem(subNode)}
+      </w:p>
+    `;
   });
-  // Workaround to prevent last item to fall off the list
-  html += `</${type}><br>`;
-  context.document.body.insertHtml(html, Word.InsertLocation.end);
+  ooxml = `
+    <pkg:package xmlns:pkg="http://schemas.microsoft.com/office/2006/xmlPackage">
+    <pkg:part pkg:name="/_rels/.rels" pkg:contentType="application/vnd.openxmlformats-package.relationships+xml">
+      <pkg:xmlData>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+        </Relationships>
+      </pkg:xmlData>
+    </pkg:part>
+    <pkg:part pkg:name="/word/document.xml" pkg:contentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml">
+      <pkg:xmlData>
+        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" >
+        <w:p />
+        ${ooxml}
+        <w:p />
+        </w:document>
+      </pkg:xmlData>
+    </pkg:part>
+    ${type === 'unordered' ? unorderedListSpec : ''}
+    </pkg:package>
+  `;
+  context.document.body.insertOoxml(ooxml, Word.InsertLocation.end);
   await context.sync();
 };
 
 const getListItem = (node, text='') => {
   if (node.$class === definedNodes.text) {
-    return node.text;
+    return `
+      <w:r>
+        <w:t xml:space="preserve">${sanitizeHtmlChars(node.text)}</w:t>
+      </w:r>
+    `;
   }
   if (node.$class === definedNodes.variable) {
-    return node.value;
+    return `
+      <w:sdt>
+        <w:sdtPr>
+          <w:alias w:val="${node.name.toUpperCase()[0]}${node.name.substring(1)}"/>
+          <w:tag w:val="${node.name}"/>
+        </w:sdtPr>
+        <w:sdtContent>
+          <w:r>
+            <w:rPr>
+              <w:highlight w:val="green"/>
+            </w:rPr>
+            <w:t>${sanitizeHtmlChars(node.value)}</w:t>
+          </w:r>
+        </w:sdtContent>
+     </w:sdt>
+    `;
   }
   if (node.$class === definedNodes.softbreak) {
     return ' ';
@@ -139,10 +190,10 @@ const renderNodes = (context, node, counter, parent=null) => {
   if (node.$class === definedNodes.listBlock || node.$class === definedNodes.list) {
     switch (node.type) {
     case 'ordered':
-      insertList(context, node, 'ol');
+      insertList(context, node, 'ordered');
       return;
     case 'bullet':
-      insertList(context, node, 'ul');
+      insertList(context, node, 'unordered');
       return;
     default:
       return;

--- a/src/utils/SanitizeHtmlChars/index.js
+++ b/src/utils/SanitizeHtmlChars/index.js
@@ -1,0 +1,5 @@
+const sanitizeHtmlChars = node => {
+  return node.replace(/>/g, '&gt;').replace(/</g, '&lt;');
+};
+
+export default sanitizeHtmlChars;


### PR DESCRIPTION
Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>

These changes render `org.accordproject.ciceromark.ListVariable` and `org.accordproject.commonmark.List`. The way they have been rendered are exactly same. **Why?** Since these lists can only be rendered at once via [`insertHtml`](https://docs.microsoft.com/en-us/javascript/api/word/word.body?view=word-js-preview#inserthtml-html--insertlocation-), which takes in HTML as a string, we can't attach variables in some texts inside it.

But still, I feel it's not required since the purpose of making any text a variable in our project is to allow a user to amend the value of variables simultaneously which is not required in a `listVariable`.

One can render `Volumediscountolist` and `Volumediscountulist` to test this feature.