### PR TITLE
fix(TemplateLibrary): Upload template Working

### DIFF
--- a/src/components/TemplateLibrary/index.js
+++ b/src/components/TemplateLibrary/index.js
@@ -34,9 +34,8 @@ const LibraryComponent = () => {
     const fileUploaded = event.target.files[0];
     try {
       const template = await Template.fromArchive(fileUploaded);
-      const templateIdentifier = template.getIdentifier();
       const ciceroMark = templateToCiceroMark(template);
-      setup(ciceroMark, templateIdentifier);
+      setup(ciceroMark, template);
     }
     catch (error) {
       Office.context.ui.displayDialogAsync(`${window.location.origin}/bad-file.html`, { width: 30, height: 8 });


### PR DESCRIPTION
Signed-off-by: d-e-v-esh <59534570+d-e-v-esh@users.noreply.github.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #35 
<!--- Provide an overall summary of the pull request -->


Clicking on the `Upload your template` button and selecting a template should render that particular template (`.cta`) file but that was not working because => `setup` function (the function that is responsible to render templates on the document) was being called with incorrect values inside `uploadYourTemplate` function


### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Calling the `setup` function with the correct values fixes this bug.
- Beforehand it was being called with the  `ciceromark` (the JSON object) and `templateIdentifier`.
- It should be called with `ciceromark` and the uploaded `template` file.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

![aH2YeC9XQf](https://user-images.githubusercontent.com/59534570/113412017-d91f7780-93d4-11eb-99ae-050484037dd5.gif)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [x] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [x] Appropriate labels, alt text, and instructions
