### PR TITLE
feature: Quotation Marks in Variable Values - #39

### DIFF
--- a/src/utils/CiceroMarkToOOXML.js
+++ b/src/utils/CiceroMarkToOOXML.js
@@ -1,4 +1,5 @@
 import sanitizeHtmlChars from './SanitizeHtmlChars';
+import sanitizeStringValues from './SanitizeStringValues';
 import titleGenerator from './TitleGenerator';
 
 let globalOoxml;
@@ -108,7 +109,7 @@ const insertVariable = (title, tag, value, type) => {
             <w:sz w:val="24"/>
             <w:highlight w:val="green"/>
           </w:rPr>
-          <w:t xml:space="preserve">${sanitizeHtmlChars(value)}</w:t>
+          <w:t xml:space="preserve">${sanitizeStringValues(sanitizeHtmlChars(value))}</w:t>
         </w:r>
       </w:sdtContent>
     </w:sdt>

--- a/src/utils/SanitizeStringValues.js
+++ b/src/utils/SanitizeStringValues.js
@@ -1,0 +1,17 @@
+/**
+ * Removes the unnecessary quotation marks in the string
+ *
+ * @param {*} value Value to sanitize.
+ * @returns {string} Sanitized Value after replacing quotation marks
+ */
+const sanitizeStringValues = value => {
+  if (typeof value === 'string') {
+    const len = value.length;
+    if (value[0]=='"' && value[len-1]=='"') {
+      return value.substr(1, len-2);
+    }
+  }
+  return value;
+};
+
+export default sanitizeStringValues;

--- a/src/utils/SanitizeStringValues.js
+++ b/src/utils/SanitizeStringValues.js
@@ -1,5 +1,5 @@
 /**
- * Removes the unnecessary quotation marks in the string
+ * Strips off the quotation marks from the first and last position.
  *
  * @param {*} value Value to sanitize.
  * @returns {string} Sanitized Value after replacing quotation marks


### PR DESCRIPTION
Strip off the quotation marks in variable values

Signed-off-by: K-Kumar-01 <59891164+K-Kumar-01@users.noreply.github.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #39 <CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Added a function `sanitizeStringValues` 
- <TWO> Strips of the quotation marks if they are present in first and last position.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
![Screenshot (64)](https://user-images.githubusercontent.com/59891164/117119360-8d833380-adaf-11eb-872e-a97686092f13.png)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
